### PR TITLE
Fix SSH Key File Management

### DIFF
--- a/app/controllers/keys_controller.rb
+++ b/app/controllers/keys_controller.rb
@@ -10,16 +10,16 @@ class KeysController < ApplicationController
     tmp = Tempfile.new("temp_keys")
 
     file_data.each { |l| tmp << l }
-    tmp.write(new_key)
+    tmp.write "#{new_key}\n"
     tmp.close
 
-    if FileUtils.mv(tmp.path, Rails.application.config.ssh_keys, :preserve => true)
+    if `cp --no-preserve=mode,ownership #{tmp.path} #{Rails.application.config.ssh_keys}`
       flash[:success] = 'SSH key successfully added'
     else
       flash[:danger] = 'Encountered an error whilst trying to add the SSH key'
     end
 
-    file.close
+    tmp.delete
 
     redirect_to ssh_path
   end
@@ -30,11 +30,13 @@ class KeysController < ApplicationController
     file_data.each { |l| tmp << l unless l == params[:key] }
     tmp.close
 
-    if FileUtils.mv(tmp.path, Rails.application.config.ssh_keys, :preserve => true)
+    if `cp --no-preserve=mode,ownership #{tmp.path} #{Rails.application.config.ssh_keys}`
       flash[:success] = 'SSH key successfully removed'
     else
       flash[:danger] = 'Encountered an error whilst trying to remove the SSH key'
     end
+
+    tmp.delete
 
     redirect_to ssh_path
   end

--- a/app/controllers/keys_controller.rb
+++ b/app/controllers/keys_controller.rb
@@ -7,9 +7,13 @@ class KeysController < ApplicationController
   end
 
   def create
-    file = File.open('tmp/keys', 'a')
+    tmp = Tempfile.new("temp_keys")
 
-    if file.write(new_key)
+    file_data.each { |l| tmp << l }
+    tmp.write(new_key)
+    tmp.close
+
+    if FileUtils.mv(tmp.path, Rails.application.config.ssh_keys, :preserve => true)
       flash[:success] = 'SSH key successfully added'
     else
       flash[:danger] = 'Encountered an error whilst trying to add the SSH key'
@@ -26,7 +30,7 @@ class KeysController < ApplicationController
     file_data.each { |l| tmp << l unless l == params[:key] }
     tmp.close
 
-    if FileUtils.mv(tmp.path, Rails.application.config.ssh_keys)
+    if FileUtils.mv(tmp.path, Rails.application.config.ssh_keys, :preserve => true)
       flash[:success] = 'SSH key successfully removed'
     else
       flash[:danger] = 'Encountered an error whilst trying to remove the SSH key'


### PR DESCRIPTION
Currently the SSH key management suffers from:
- `Create` editing a file called `tmp/keys` instead of using the environment SSH file
- `Delete` modifying the destination permissions with the tempfile (making the SSH file lose the permissions to function properly)

This PR addresses these issues by using a cp command in the shell to preserve permissions on copy and by deleting the tempfile after the checks.