### PR TITLE
Restrict modifiable network variables

### DIFF
--- a/app/controllers/network_controller.rb
+++ b/app/controllers/network_controller.rb
@@ -9,7 +9,7 @@ class NetworkController < ApplicationController
     tmp = Tempfile.new("temp_vars")
 
     file_data.each do |line|
-      if line.start_with?('export')
+      if line.include?("INTERNAL") || line.include?("EXTERNAL")
         content = line.split("export")[1].split("=")
         variable = content[0]
         tail = content[1].split('"')[2]

--- a/app/controllers/network_controller.rb
+++ b/app/controllers/network_controller.rb
@@ -1,8 +1,8 @@
 class NetworkController < ApplicationController
   def index
-    @file_lines = file_data
-    @internal_vars = @file_lines.select { |l| l.include? "INTERNAL" }
-    @external_vars = @file_lines.select { |l| l.include? "EXTERNAL" }
+    file_lines = file_data
+    @internal_vars = file_lines.select { |l| l.include? "INTERNAL" }
+    @external_vars = file_lines.select { |l| l.include? "EXTERNAL" }
   end
 
   def edit

--- a/app/controllers/network_controller.rb
+++ b/app/controllers/network_controller.rb
@@ -1,6 +1,8 @@
 class NetworkController < ApplicationController
   def index
     @file_lines = file_data
+    @internal_vars = @file_lines.select { |l| l.include? "INTERNAL" }
+    @external_vars = @file_lines.select { |l| l.include? "EXTERNAL" }
   end
 
   def edit

--- a/app/views/network/index.html.erb
+++ b/app/views/network/index.html.erb
@@ -36,6 +36,7 @@
         </tbody>
       </table>
     </div>
+    <br>
   <% end %>
   <%= f.submit "Submit Changes",
                disable_with: 'Saving...',

--- a/app/views/network/index.html.erb
+++ b/app/views/network/index.html.erb
@@ -6,34 +6,37 @@
                 class: 'w-50 center'
              } do |f| %>
   <h1 class="text-center">Manage Network Variables</h1>
-  <div class="table-responsive">
-    <table class="table table-bordered center">
-      <thead>
-        <tr>
-          <th style="width: 30%;">Variable</th>
-          <th>Value</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @file_lines.each do |line| %>
-          <% next unless line.start_with?('export') %>
-
-          <% content = line.split("export")[1].split("=") %>
-          <% variable = content[0] %>
-          <% value = content[1].split('"')[1] %>
-
+  <% [@internal_vars, @external_vars].each do |vars| %>
+    <div class="table-responsive">
+      <h2 class="text-center">
+        <%= vars.first.include?("INTERNAL") ? 'Internal' : 'External' %>
+      </h2>
+      <table class="table table-bordered center">
+        <thead>
           <tr>
-            <td>
-              <code><%= variable %></code>
-            </td>
-            <td>
-              <%= f.text_field variable, class: 'form-control', value: value %>
-            </td>
+            <th style="width: 30%;">variable</th>
+            <th>value</th>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
+        </thead>
+        <tbody>
+          <% vars.each do |var| %>
+            <% content = var.split("export")[1].split("=") %>
+            <% variable = content[0] %>
+            <% value = content[1].split('"')[1] %>
+
+            <tr>
+              <td>
+                <code><%= variable %></code>
+              </td>
+              <td>
+                <%= f.text_field variable, class: 'form-control', value: value %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
   <%= f.submit "Submit Changes",
                disable_with: 'Saving...',
                class: 'btn btn-primary btn-block center mb-3' %>

--- a/app/views/network/index.html.erb
+++ b/app/views/network/index.html.erb
@@ -14,8 +14,8 @@
       <table class="table table-bordered center">
         <thead>
           <tr>
-            <th style="width: 30%;">variable</th>
-            <th>value</th>
+            <th style="width: 30%;">Variable</th>
+            <th>Value</th>
           </tr>
         </thead>
         <tbody>

--- a/app/views/network/index.html.erb
+++ b/app/views/network/index.html.erb
@@ -5,8 +5,8 @@
                 id: 'network-var-edit-form',
                 class: 'w-50 center'
              } do |f| %>
+  <h1 class="text-center">Manage Network Variables</h1>
   <div class="table-responsive">
-    <h1 class="text-center">Manage Network Variables</h1>
     <table class="table table-bordered center">
       <thead>
         <tr>


### PR DESCRIPTION
Resolves #13. The variables available for modification on the `Network Management` page have been restricted to only those containing `alces_INTERNAL` or `alces_EXTERNAL`. These variable groups have also been grouped and separated into their own respective table. Although there is still only one submission button that pushes any changes made to the internal or external variables.

![image](https://user-images.githubusercontent.com/36155339/53350445-fe4c7c80-3916-11e9-8f4e-4bdf4dc01730.png)
