### PR TITLE
Reapply the form styling to the login page

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -4,7 +4,7 @@
   <h1><%= Rails.application.config.application_name %> Appliance </h1>
   <div>
     <div>
-      <%= form_for(:session, url: login_path) do |f| %>
+      <%= form_for(:session, url: login_path, html: { class: 'styled-form' }) do |f| %>
         <%= f.label :username %>
         <%= f.text_field :username, class: 'form-control' %>
 


### PR DESCRIPTION
When I previously adjusted the default form styling I forgot to reapply the styling for this page. This PR returns the login form to its former glory.