### PR TITLE
Fix saving issue

### DIFF
--- a/app/controllers/cluster_controller.rb
+++ b/app/controllers/cluster_controller.rb
@@ -10,11 +10,19 @@ class ClusterController < ApplicationController
   end
 
   def restart
-    run_shell_command("shutdown -r +1 'Reboot requested via web interface'")
+    if run_shell_command("shutdown -r +1 'Reboot requested via web interface'")
+      flash[:success] = 'Restarting machine'
+    else
+      flash[:danger] = 'Encountered an error whilst trying to restart the machine'
+    end
   end
 
   def stop
-    run_shell_command("shutdown -h +1 'Shutdown requested via web interface'")
+    if run_shell_command("shutdown -h +1 'Shutdown requested via web interface'")
+      flash[:success] = 'Stopping the machine'
+    else
+      flash[:danger] = 'Encountered an error whilst trying to stop the machine'
+    end
   end
 
   private

--- a/app/controllers/cluster_controller.rb
+++ b/app/controllers/cluster_controller.rb
@@ -15,6 +15,8 @@ class ClusterController < ApplicationController
     else
       flash[:danger] = 'Encountered an error whilst trying to restart the machine'
     end
+
+    redirect_to cluster_path
   end
 
   def stop
@@ -23,6 +25,8 @@ class ClusterController < ApplicationController
     else
       flash[:danger] = 'Encountered an error whilst trying to stop the machine'
     end
+
+    redirect_to cluster_path
   end
 
   private


### PR DESCRIPTION
This PR aims to resolve #14. After interacting with the machine management tool the user will be redirected and a message will flash on the page. This should prevent Chrome from wanting to save a non-existent file.