### PR TITLE
Run network setup script after configuration changes are made

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ export APPLICATION_NAME=ABC # Optionally set for development
 export SSH_KEYS_FILE_PATH=ABC
 export APPLIANCE_INFORMATION_FILE_PATH=ABC
 export NETWORK_VARIABLES_FILE_PATH=ABC
+export NETWORK_SETUP_SCRIPT_FILE_PATH=ABC
 
 # Set the following in production
 #SECRET_KEY_BASE=ABC

--- a/app/controllers/network_controller.rb
+++ b/app/controllers/network_controller.rb
@@ -28,7 +28,11 @@ class NetworkController < ApplicationController
     tmp.close
 
     if run_shell_command("cp --no-preserve=mode,ownership #{tmp.path} #{network_variables}")
-      flash[:success] = 'Network configuration successfully modified'
+      if run_shell_command("alces_RERUN=true bash #{network_setup}")
+        flash[:success] = 'Network configuration successfully modified'
+      else
+        flash[:danger] = 'Encountered an error whilst trying to run the setup script'
+      end
     else
       flash[:danger] = 'Encountered an error whilst trying to modify the network configuration'
     end

--- a/app/controllers/network_controller.rb
+++ b/app/controllers/network_controller.rb
@@ -27,7 +27,7 @@ class NetworkController < ApplicationController
 
     tmp.close
 
-    if run_shell_command("cp --no-preserve=mode,ownership #{tmp.path} #{Rails.application.config.network_variables}")
+    if run_shell_command("cp --no-preserve=mode,ownership #{tmp.path} #{network_variables}")
       flash[:success] = 'Network configuration successfully modified'
     else
       flash[:danger] = 'Encountered an error whilst trying to modify the network configuration'

--- a/app/controllers/network_controller.rb
+++ b/app/controllers/network_controller.rb
@@ -1,4 +1,9 @@
 class NetworkController < ApplicationController
+
+  delegate :network_variables,
+           :network_setup,
+           to: 'Rails.application.config'
+
   def index
     file_lines = file_data
     @internal_vars = file_lines.select { |l| l.include? "INTERNAL" }

--- a/app/controllers/network_controller.rb
+++ b/app/controllers/network_controller.rb
@@ -27,7 +27,7 @@ class NetworkController < ApplicationController
 
     tmp.close
 
-    if `cp --no-preserve=mode,ownership #{tmp.path} #{Rails.application.config.network_variables}`
+    if run_shell_command("cp --no-preserve=mode,ownership #{tmp.path} #{Rails.application.config.network_variables}")
       flash[:success] = 'Network configuration successfully modified'
     else
       flash[:danger] = 'Encountered an error whilst trying to modify the network configuration'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -63,4 +63,5 @@ Rails.application.configure do
   config.appliance_information = ENV['APPLIANCE_INFORMATION_FILE_PATH']
   config.ssh_keys = ENV['SSH_KEYS_FILE_PATH']
   config.network_variables = ENV['NETWORK_VARIABLES_FILE_PATH']
+  config.network_setup = ENV['NETWORK_SETUP_SCRIPT_FILE_PATH']
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,4 +96,5 @@ Rails.application.configure do
   config.appliance_information = ENV['APPLIANCE_INFORMATION_FILE_PATH']
   config.ssh_keys = ENV['SSH_KEYS_FILE_PATH']
   config.network_variables = ENV['NETWORK_VARIABLES_FILE_PATH']
+  config.network_setup = ENV['NETWORK_SETUP_SCRIPT_FILE_PATH']
 end


### PR DESCRIPTION
As [requested ](https://github.com/alces-software/overware/issues/7#issuecomment-467534603) the setup script will now be run after configuration settings have been successfully saved.