### PR TITLE
Add method for configuring global scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,26 @@ export NETWORK_SETUP_SCRIPT_FILE_PATH=ABC
 # Set the following in production
 #SECRET_KEY_BASE=ABC
 #RAILS_SERVE_STATIC_FILES=true
+
+# Script Configuration
+export ENTRYPOINT=/appliance/scripts/action.sh
+
+## VPN Scripts
+export VPN_START="vpn state start"
+export VPN_STOP="vpn state stop"
+export VPN_RESTART="vpn state restart"
+export VPN_NAME="vpn name"
+
+## Network Scripts
+export NETWORK_GET="network get"
+export NETWORK_SET="network set"
+export NETWORK_SHOW="network show"
+
+## SSH Scripts
+export SSH_ADD="ssh add-key"
+export SSH_GET="ssh get-keys"
+export SSH_REMOVE="ssh remove-key"
+
+## Power Scripts
+export POWER_OFF="power off"
+export POWER_RESTART="power restart"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,13 @@ class ApplicationController < ActionController::Base
     system(command, out: File::NULL)
   end
 
+  def run_global_script(command, *args)
+    system(
+      "bash #{ENV['ENTRYPOINT']} #{command} #{args.join(' ')}",
+      out: File::NULL
+    )
+  end
+
   def bolt_on_enabled(name)
     BoltOn.find_by(name: name).enabled?
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,7 @@ class ApplicationController < ActionController::Base
     )
   end
 
+  # Deprecated and will be removed once run_global_script has been utilised
   def run_shell_command(command)
     system(command, out: File::NULL)
   end


### PR DESCRIPTION
Configuring global scripts in use by `Overware` is now as simple as adjusting some environment variables. Found within `.env` is a new section relating to global script configuration with a variable for the master script entrypoint (as described in #29) and a variable for each customisation found [here](https://github.com/alces-software/appliance-configuration#running-customisations); excluding the firewall scripts until they are relevant to `Overware`.

It will be necessary to restart the server to see any changes made to `.env` reflected in the web application.

This covers #29 but I will not resolve that issue until we're happy with this process. 