### PR TITLE
Refactor network management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,6 @@ export APPLICATION_NAME=ABC # Optionally set for development
 export SSH_KEYS_FILE_PATH=ABC
 export APPLIANCE_INFORMATION_FILE_PATH=ABC
 export NETWORK_VARIABLES_FILE_PATH=ABC
-export NETWORK_SETUP_SCRIPT_FILE_PATH=ABC
 
 # Set the following in production
 #SECRET_KEY_BASE=ABC

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   include Clearance::Controller
+  require 'open3'
 
   def authenticate(params)
     User.authenticate(
@@ -14,10 +15,7 @@ class ApplicationController < ActionController::Base
   end
 
   def run_global_script(command, *args)
-    system(
-      "bash #{ENV['ENTRYPOINT']} #{command} #{args.join(' ')}",
-      out: File::NULL
-    )
+    Open3.capture3("bash #{ENV['ENTRYPOINT']} #{command} #{args.join(' ')}")
   end
 
   def bolt_on_enabled(name)

--- a/app/controllers/network_controller.rb
+++ b/app/controllers/network_controller.rb
@@ -57,6 +57,11 @@ class NetworkController < ApplicationController
     out.lines.map
   end
 
+  def network_show_output
+    out, err, status = run_global_script(ENV['NETWORK_SHOW'])
+    out.lines.map
+  end
+
   def file_data
     IO.binread(Rails.application.config.network_variables).lines.map
   end

--- a/app/controllers/network_controller.rb
+++ b/app/controllers/network_controller.rb
@@ -5,9 +5,8 @@ class NetworkController < ApplicationController
            to: 'Rails.application.config'
 
   def index
-    network_vars = network_get_output
-    @internal_vars = network_vars.select { |l| l.include? "INTERNAL" }
-    @external_vars = network_vars.select { |l| l.include? "EXTERNAL" }
+    @network_vars = network_get_output
+    @networks = network_show_output
   end
 
   def edit
@@ -59,7 +58,7 @@ class NetworkController < ApplicationController
 
   def network_show_output
     out, err, status = run_global_script(ENV['NETWORK_SHOW'])
-    out.lines.map
+    out.split("\n\n").map { |n| n.split("\n") }
   end
 
   def file_data

--- a/app/controllers/network_controller.rb
+++ b/app/controllers/network_controller.rb
@@ -5,9 +5,9 @@ class NetworkController < ApplicationController
            to: 'Rails.application.config'
 
   def index
-    file_lines = network_get_output
-    @internal_vars = file_lines.select { |l| l.include? "INTERNAL" }
-    @external_vars = file_lines.select { |l| l.include? "EXTERNAL" }
+    network_vars = network_get_output
+    @internal_vars = network_vars.select { |l| l.include? "INTERNAL" }
+    @external_vars = network_vars.select { |l| l.include? "EXTERNAL" }
   end
 
   def edit

--- a/app/controllers/network_controller.rb
+++ b/app/controllers/network_controller.rb
@@ -1,7 +1,6 @@
 class NetworkController < ApplicationController
 
   delegate :network_variables,
-           :network_setup,
            to: 'Rails.application.config'
 
   def index

--- a/app/controllers/network_controller.rb
+++ b/app/controllers/network_controller.rb
@@ -5,7 +5,7 @@ class NetworkController < ApplicationController
            to: 'Rails.application.config'
 
   def index
-    file_lines = file_data
+    file_lines = network_get_output
     @internal_vars = file_lines.select { |l| l.include? "INTERNAL" }
     @external_vars = file_lines.select { |l| l.include? "EXTERNAL" }
   end
@@ -15,20 +15,24 @@ class NetworkController < ApplicationController
 
     file_data.each do |line|
       if line.include?("INTERNAL") || line.include?("EXTERNAL")
-        content = line.split("export")[1].split("=")
-        variable = content[0]
-        tail = content[1].split('"')[2]
+        content = line.split("=")
+        variable = content[0].remove("export ")
+        original_value = content[1].split('"')[1]
 
-        line = "export#{variable}=\"#{network_params[variable]}\"#{tail}"
+        if original_value.empty?
+          line = line.insert(line.index('"') + 1, network_params[variable])
+        else
+          line = line.sub original_value, network_params[variable]
+        end
       end
 
       tmp << line
     end
 
     tmp.close
-
     if run_shell_command("cp --no-preserve=mode,ownership #{tmp.path} #{network_variables}")
-      if run_shell_command("alces_RERUN=true bash #{network_setup}")
+      out, err, status = run_global_script(ENV['NETWORK_SET'])
+      if status.success?
         flash[:success] = 'Network configuration successfully modified'
       else
         flash[:danger] = 'Encountered an error whilst trying to run the setup script'
@@ -46,6 +50,11 @@ class NetworkController < ApplicationController
 
   def network_params
     params[:network]
+  end
+
+  def network_get_output
+    out, err, status = run_global_script(ENV['NETWORK_GET'])
+    out.lines.map
   end
 
   def file_data

--- a/app/controllers/vpn_controller.rb
+++ b/app/controllers/vpn_controller.rb
@@ -1,7 +1,8 @@
 class VpnController < ApplicationController
   def start
     return unless bolt_on_enabled('VPN')
-    if run_global_script(ENV['VPN_START'])
+    out, err, status = run_global_script(ENV['VPN_START'])
+    if status.success?
       flash[:success] = 'VPN started'
     else
       flash[:danger] = 'Enountered an error whilst trying to start the VPN'
@@ -12,7 +13,8 @@ class VpnController < ApplicationController
 
   def stop
     return unless bolt_on_enabled('VPN')
-    if run_global_script(ENV['VPN_STOP'])
+    out, err, status = run_global_script(ENV['VPN_STOP'])
+    if status.success?
       flash[:success] = 'VPN stopped'
     else
       flash[:danger] = 'Encountered an error whilst trying to stop the VPN'
@@ -23,7 +25,8 @@ class VpnController < ApplicationController
 
   def restart
     return unless bolt_on_enabled('VPN')
-    if run_global_script(ENV['VPN_RESTART'])
+    out, err, status = run_global_script(ENV['VPN_RESTART'])
+    if status.success?
       flash[:success] = 'VPN restarted'
     else
       flash[:danger] = 'Encountered an error whilst trying to restart the VPN'

--- a/app/views/network/_modify_network_modal.html.erb
+++ b/app/views/network/_modify_network_modal.html.erb
@@ -1,0 +1,46 @@
+<div id="<%= name %>_network_modal" class="modal fade" role="dialog">
+  <div class="modal-dialog modal-dialog-centered modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title center"><%= name %> Network</h4>
+      </div>
+      <div class="modal-body">
+        <div class="table-responsive">
+          <h5 class="text-center"> Modify Network Variables </h5>
+          <br>
+          <table class="table table-bordered center">
+            <thead>
+              <tr>
+                <th style="width: 30%;">Variable</th>
+                <th>Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @network_vars.select { |v| v.include?(name.upcase) }.each do |var| %>
+                <% content = var.split("=") %>
+                <% variable = content[0] %>
+                <% value = content[1].split("\n") %>
+
+                <tr>
+                  <td>
+                    <code><%= variable %></code>
+                  </td>
+                  <td>
+                    <%= f.text_field variable, class: 'form-control', value: value %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+        <br>
+        <%= f.submit "Submit Changes",
+                     disable_with: 'Saving...',
+                     class: 'btn btn-primary btn-block center mb-3' %>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal"> Close </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/network/index.html.erb
+++ b/app/views/network/index.html.erb
@@ -7,7 +7,6 @@
                 id: 'network-var-edit-form',
                 class: 'w-50 center'
              } do |f| %>
-  <h1 class="text-center">Manage Network Variables</h1>
   <br>
   <% @networks.each do |network| %>
     <div>

--- a/app/views/network/index.html.erb
+++ b/app/views/network/index.html.erb
@@ -22,9 +22,9 @@
         </thead>
         <tbody>
           <% vars.each do |var| %>
-            <% content = var.split("export")[1].split("=") %>
+            <% content = var.split("=") %>
             <% variable = content[0] %>
-            <% value = content[1].split('"')[1] %>
+            <% value = content[1].split("\n") %>
 
             <tr>
               <td>

--- a/app/views/network/index.html.erb
+++ b/app/views/network/index.html.erb
@@ -14,7 +14,7 @@
         <div class="card-header">
           <% network_name = network.shift.split(' ')[1] %>
           <h5 style="display: inline-block"><%= network_name %> Network</h5>
-          <%= link_to raw('<i class="fa fa-pencil fa-pull-right"></i>'),
+          <%= link_to raw('<i class="fa fa-pencil fa-pull-right mt-1"></i>'),
                       "##{network_name}_network_modal",
                       "data-toggle": 'modal'
           %>

--- a/app/views/network/index.html.erb
+++ b/app/views/network/index.html.erb
@@ -8,39 +8,26 @@
                 class: 'w-50 center'
              } do |f| %>
   <h1 class="text-center">Manage Network Variables</h1>
-  <% [@internal_vars, @external_vars].each do |vars| %>
-    <div class="table-responsive">
-      <h2 class="text-center">
-        <%= vars.first.include?("INTERNAL") ? 'Internal' : 'External' %>
-      </h2>
-      <table class="table table-bordered center">
-        <thead>
-          <tr>
-            <th style="width: 30%;">Variable</th>
-            <th>Value</th>
-          </tr>
-        </thead>
-        <tbody>
-          <% vars.each do |var| %>
-            <% content = var.split("=") %>
-            <% variable = content[0] %>
-            <% value = content[1].split("\n") %>
-
-            <tr>
-              <td>
-                <code><%= variable %></code>
-              </td>
-              <td>
-                <%= f.text_field variable, class: 'form-control', value: value %>
-              </td>
-            </tr>
+  <br>
+  <% @networks.each do |network| %>
+    <div>
+      <div class="card d-flex center">
+        <div class="card-header">
+          <% network_name = network.shift.split(' ')[1] %>
+          <h5 style="display: inline-block"><%= network_name %> Network</h5>
+          <%= link_to raw('<i class="fa fa-pencil fa-pull-right"></i>'),
+                      "##{network_name}_network_modal",
+                      "data-toggle": 'modal'
+          %>
+        </div>
+        <div class="card-body">
+          <% network.each do |variable| %>
+            <%= CommonMarker.render_html(variable, :DEFAULT, [:table]).html_safe %>
           <% end %>
-        </tbody>
-      </table>
+        </div>
+      </div>
     </div>
     <br>
+    <%= render 'network/modify_network_modal', name: network_name, f: f %>
   <% end %>
-  <%= f.submit "Submit Changes",
-               disable_with: 'Saving...',
-               class: 'btn btn-primary btn-block center mb-3' %>
 <% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -63,5 +63,4 @@ Rails.application.configure do
   config.appliance_information = ENV['APPLIANCE_INFORMATION_FILE_PATH']
   config.ssh_keys = ENV['SSH_KEYS_FILE_PATH']
   config.network_variables = ENV['NETWORK_VARIABLES_FILE_PATH']
-  config.network_setup = ENV['NETWORK_SETUP_SCRIPT_FILE_PATH']
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,5 +96,4 @@ Rails.application.configure do
   config.appliance_information = ENV['APPLIANCE_INFORMATION_FILE_PATH']
   config.ssh_keys = ENV['SSH_KEYS_FILE_PATH']
   config.network_variables = ENV['NETWORK_VARIABLES_FILE_PATH']
-  config.network_setup = ENV['NETWORK_SETUP_SCRIPT_FILE_PATH']
 end


### PR DESCRIPTION
After efforts made in #33 the `Network Management` page was in need of extensive refactoring both internally and externally. This PR revamps this page so that it works off of the following global scripts:
* `network get`
* `network show`
* `network set`

This page now works by grabbing all networks and their associated variables with the first two commands; get and show.

The former collects all network variables so that they can be viewed and edited within a modal on the `Network Management` page.

The latter is used to dynamically render a card in supported markdown with an edit button in the top right hand corner. Clicking this button will open the modal mentioned previously that contains all variables associated with that network.

As the data rendered within the cards is retrieved from one of the global scripts outside of `Overware` it can be edited very easily without having to restart or change anything within the web application. This means that the space within the card should be viewed as a canvas for displaying anything you want about a network.

## Example Page

![network-modify](https://user-images.githubusercontent.com/36155339/56222651-5163c580-6064-11e9-8b9e-a74d1fde161b.gif)

Resolves #26 when merged.

[Trello](https://trello.com/c/3WyQnQ3o/8-refactor-network-management)
