### PR TITLE
Display VPN name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,7 @@ export VPN_START="vpn state start"
 export VPN_STOP="vpn state stop"
 export VPN_RESTART="vpn state restart"
 export VPN_NAME="vpn name"
+export VPN_STATUS="vpn status"
 
 ## Network Scripts
 export NETWORK_GET="network get"

--- a/app/controllers/cluster_controller.rb
+++ b/app/controllers/cluster_controller.rb
@@ -3,10 +3,13 @@ class ClusterController < ApplicationController
 
   def index
     #BoltOns
-    @vpn = bolt_on_enabled('VPN')
+    @vpn = {
+      enabled: bolt_on_enabled('VPN'),
+      status: vpn_status,
+      name: vpn_name[0]
+    }
 
     @content = appliance_information
-    @active = vpn_status
   end
 
   def restart

--- a/app/controllers/cluster_controller.rb
+++ b/app/controllers/cluster_controller.rb
@@ -44,7 +44,7 @@ class ClusterController < ApplicationController
   end
 
   def vpn_status
-    run_shell_command("systemctl is-active --quiet openvpn@flightcenter")
+    run_global_script(ENV['VPN_STATUS'])[2].success?
   end
 
   def vpn_name

--- a/app/controllers/cluster_controller.rb
+++ b/app/controllers/cluster_controller.rb
@@ -43,4 +43,8 @@ class ClusterController < ApplicationController
   def vpn_status
     run_shell_command("systemctl is-active --quiet openvpn@flightcenter")
   end
+
+  def vpn_name
+    run_global_script(ENV['VPN_NAME'])
+  end
 end

--- a/app/views/cluster/_vpn_controls.html.erb
+++ b/app/views/cluster/_vpn_controls.html.erb
@@ -1,10 +1,10 @@
-<% if @vpn %>
+<% if @vpn[:enabled] %>
   <div class="card d-flex center mb-2">
     <h5 class="card-header">VPN Management</h5>
     <div class="card-body">
-      <h5 class="card-title <%= @active ? 'text-success' : 'text-danger' %>">
+      <h5 class="card-title <%= @vpn[:status] ? 'text-success' : 'text-danger' %>">
         <i class="fa fa-circle mr-2" aria-hidden="true"></i>
-        <%= @active ? 'Active' : 'Inactive' %>
+        <%= @vpn[:name] %>
       </h5>
       <div class="btn-group d-flex">
         <% ['start', 'restart'].each do |action| %>


### PR DESCRIPTION
Resolves #27. The name of the VPN is now displayed within the `VPN Management` widget on the main page. This replaces the text that previously stated whether or not the connection was active.

This PR also utilises a new [global script](https://github.com/alces-software/appliance-configuration/blob/dev/openflight-appliance/scripts/vpn/status.sh) for grabbing the status of the VPN.

[Trello](https://trello.com/c/Vj6L88xT/11-display-name-of-vpn-connection)

