### PR TITLE
Firewall Management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,7 @@ export SSH_REMOVE="ssh remove-key"
 ## Power Scripts
 export POWER_OFF="power off"
 export POWER_RESTART="power restart"
+
+## Firewall Scripts
+export SSH_ENABLE="firewall add-service ssh external"
+export SSH_DISABLE="firewall remove-service ssh external"

--- a/app/controllers/network_controller.rb
+++ b/app/controllers/network_controller.rb
@@ -44,6 +44,26 @@ class NetworkController < ApplicationController
     redirect_to network_path
   end
 
+  def add_ssh_service
+    if run_global_script(ENV['SSH_ENABLE'])[2].success?
+      flash[:success] = 'SSH enabled on the external interface'
+    else
+      flash[:danger] = 'Encountered an error whilst trying to enable SSH'
+    end
+
+    redirect_to network_path
+  end
+
+  def remove_ssh_service
+    if run_global_script(ENV['SSH_DISABLE'])[2].success?
+      flash[:success] = 'SSH disabled on the external interface'
+    else
+      flash[:danger] = 'Encountered an error whilst trying to disable SSH'
+    end
+
+    redirect_to network_path
+  end
+
   private
 
   def network_params

--- a/app/views/network/_external_ssh_controls.html.erb
+++ b/app/views/network/_external_ssh_controls.html.erb
@@ -1,0 +1,19 @@
+<div class="card d-flex center mb-2">
+  <h5 class="card-header"> Firewall Management </h5>
+  <div class="card-body">
+    <p class="card-title"> External Interface SSH </p>
+    <div class="btn-group d-flex">
+      <%= link_to 'On',
+                  firewall_add_ssh_path,
+                  class: 'btn btn-primary',
+                  method: :post
+      %>
+      <%= link_to 'Off',
+                  firewall_remove_ssh_path,
+                  class: 'btn btn-danger',
+                  method: :post,
+                  data: { confirm: 'Are you sure you wish to stop this service?' }
+      %>
+    </div>
+  </div>
+</div>

--- a/app/views/network/index.html.erb
+++ b/app/views/network/index.html.erb
@@ -1,32 +1,40 @@
 <% content_for(:title) { 'Network Management' } %>
 
-<%= form_for :network,
-             as: :post,
-             url: network_edit_path,
-             html: {
-                id: 'network-var-edit-form',
-                class: 'w-50 center'
-             } do |f| %>
-  <br>
-  <% @networks.each do |network| %>
-    <div>
-      <div class="card d-flex center">
-        <div class="card-header">
-          <% network_name = network.shift.split(' ')[1] %>
-          <h5 style="display: inline-block"><%= network_name %> Network</h5>
-          <%= link_to raw('<i class="fa fa-pencil fa-pull-right mt-1"></i>'),
-                      "##{network_name}_network_modal",
-                      "data-toggle": 'modal'
-          %>
-        </div>
-        <div class="card-body">
-          <% network.each do |variable| %>
-            <%= CommonMarker.render_html(variable, :DEFAULT, [:table]).html_safe %>
-          <% end %>
+<div class="row center mt-3" style="width: 90%;">
+  <%= form_for :network,
+               as: :post,
+               url: network_edit_path,
+               html: {
+                  id: 'network-var-edit-form',
+                  class: 'center',
+                  style: 'width: 70%;'
+               } do |f| %>
+    <% @networks.each do |network| %>
+      <div>
+        <div class="card d-flex center">
+          <div class="card-header">
+            <% network_name = network.shift.split(' ')[1] %>
+            <h5 style="display: inline-block"><%= network_name %> Network</h5>
+            <%= link_to raw('<i class="fa fa-pencil fa-pull-right mt-1"></i>'),
+                        "##{network_name}_network_modal",
+                        "data-toggle": 'modal'
+            %>
+          </div>
+          <div class="card-body">
+            <% network.each do |variable| %>
+              <%= CommonMarker.render_html(variable, :DEFAULT, [:table]).html_safe %>
+            <% end %>
+          </div>
         </div>
       </div>
-    </div>
-    <br>
-    <%= render 'network/modify_network_modal', name: network_name, f: f %>
+      <br>
+      <%= render 'network/modify_network_modal', name: network_name, f: f %>
+    <% end %>
   <% end %>
-<% end %>
+
+  <div class="col">
+    <div>
+      <%= render 'external_ssh_controls' %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ Rails.application.routes.draw do
 
     get 'network', to: 'network#index'
     post 'network/edit', to: 'network#edit'
+    post 'firewall/add-ssh', to: 'network#add_ssh_service'
+    post 'firewall/remove-ssh', to: 'network#remove_ssh_service'
 
     post 'vpn/start', to: 'vpn#start'
     post 'vpn/stop', to: 'vpn#stop'


### PR DESCRIPTION
This PR addresses #24 but after some discussions the decision was made to have this feature be baseline and not as an optional Bolt-On.

A new widget is now visible on the `Network Management` page (shown below) that allows for firewall management. Initially this will only allow the user to enable or disable external SSH into the machine but there is room for expansion on this feature in the future.

![Screenshot_2019-04-17 Network Management](https://user-images.githubusercontent.com/36155339/56300376-c51dd500-612d-11e9-9c33-107f8c21c7bb.png)

Resolves #24 when merged.

[Trello](https://trello.com/c/xL6uaZnr/13-bolt-on-ssh-toggle-for-external-interface)