### PR TITLE
Feat/asset info

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,6 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.5.0'
-
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.2'
 # Use postgresql as the database for Active Record

--- a/README.md
+++ b/README.md
@@ -96,3 +96,9 @@ A Bolt-On is an optional part of the web interface configuration. These can be e
       bolt_on.enabled = true
       bolt_on.save!
     ```
+### Assets
+
+Prerequisites:
+
+* [Flight Inventory](https://github.com/openflighthpc/flight-inventory) installed
+* [Flight Inventory Diagrams](https://github.com/alces-software/flight-inventory-diagrams) plugin installed

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -51,3 +51,16 @@ textarea {
   max-width: initial;
   max-width: max-content;
 }
+
+.btn-bordered {
+  border-style: solid;
+  border-color: black;
+  border-width: 1px;
+}
+
+.bordered {
+  border-style: solid;
+  border-color: black;
+  border-width: 1px;
+  background-color: #2794d8;
+}

--- a/app/assets/stylesheets/assets.scss
+++ b/app/assets/stylesheets/assets.scss
@@ -1,0 +1,4 @@
+.asset-name {
+  white-space: nowrap;
+  padding: 0px 4px;
+}

--- a/app/assets/stylesheets/assets.scss
+++ b/app/assets/stylesheets/assets.scss
@@ -1,3 +1,13 @@
+.parent-div {
+  position: relative;
+}
+
+.filter-bar {
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+
 .asset-name {
   white-space: nowrap;
   padding: 0px 4px;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  require 'commonmarker'
   include Clearance::Controller
   require 'open3'
 
@@ -25,5 +26,9 @@ class ApplicationController < ActionController::Base
 
   def redirect_unless_bolt_on(bolt_on)
     redirect_to root_path unless bolt_on_enabled(bolt_on)
+  end
+
+  def render_as_markdown(html)
+    CommonMarker.render_html(html, :DEFAULT, [:table])
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,8 @@ class ApplicationController < ActionController::Base
   include Clearance::Controller
   require 'open3'
 
+  helper_method :bolt_on_enabled
+
   def authenticate(params)
     User.authenticate(
       params[:session][:username],
@@ -22,7 +24,6 @@ class ApplicationController < ActionController::Base
   def bolt_on_enabled(name)
     BoltOn.find_by(name: name).enabled?
   end
-  helper_method :bolt_on_enabled
 
   def redirect_unless_bolt_on(bolt_on)
     redirect_to root_path unless bolt_on_enabled(bolt_on)
@@ -31,6 +32,4 @@ class ApplicationController < ActionController::Base
   def render_as_markdown(html)
     CommonMarker.render_html(html, :DEFAULT, [:table])
   end
-
-  helper_method :bolt_on_enabled
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,4 +31,6 @@ class ApplicationController < ActionController::Base
   def render_as_markdown(html)
     CommonMarker.render_html(html, :DEFAULT, [:table])
   end
+
+  helper_method :bolt_on_enabled
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
-  require 'commonmarker'
   include Clearance::Controller
+
+  require 'commonmarker'
   require 'open3'
 
   helper_method :bolt_on_enabled

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,4 +22,8 @@ class ApplicationController < ActionController::Base
     BoltOn.find_by(name: name).enabled?
   end
   helper_method :bolt_on_enabled
+
+  def redirect_unless_bolt_on(bolt_on)
+    redirect_to root_path unless bolt_on_enabled(bolt_on)
+  end
 end

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -7,14 +7,7 @@ class AssetsController < ApplicationController
     if params[:filter_on] and params[:filter_arg]
       cmd = cmd + " --#{params[:filter_on]} #{params[:filter_arg]}"
     end
-    @assets = {}
-    assets_list = execute(cmd)
-    assets_by_type = assets_list.split("\n#")
-    assets_by_type.each do |type_list|
-      next if type_list.empty?
-      type_list = type_list.split("\n")
-      @assets[type_list.shift] = type_list
-    end
+    @assets = get_assets(cmd)
   end
 
   def single_asset
@@ -40,5 +33,18 @@ class AssetsController < ApplicationController
     #See here: https://stackoverflow.com/a/26040994/6257573
     cmd = cmd + ';' unless cmd.match(/;$/)
     Bundler.with_clean_env { @asset_data = Open3.capture3(cmd)[0] }
+  end
+
+  #TODO potentially implement caching to prevent unnecssarily re-executing
+  # this command
+  def get_assets(cmd = 'flight inventory list')
+   assets_by_type = {}
+   asset_type_list = execute(cmd).split("\n#")
+   asset_type_list.each do |type_list|
+     next if type_list.empty?
+     type_list = type_list.split("\n")
+     assets_by_type[type_list.shift] = type_list
+   end
+   assets_by_type
   end
 end

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -3,12 +3,16 @@ class AssetsController < ApplicationController
 
   def index
     redirect_unless_bolt_on('Assets')
+    cmd = "flight inventory list"
+    if params[:filter_on] and params[:filter_arg]
+      cmd = cmd + " --#{params[:filter_on]} #{params[:filter_arg]}"
+    end
     @assets = {}
     assets_list = ''
     Bundler.with_clean_env do
       #This ';' is neccessary to force shell execution
       #See here: https://stackoverflow.com/a/26040994/6257573
-      assets_list = Open3.capture3("flight inventory list;")[0]
+      assets_list = Open3.capture3(cmd + ";")[0]
     end
     assets_by_type = assets_list.split("\n#")
     assets_by_type.each do |type_list|
@@ -30,5 +34,9 @@ class AssetsController < ApplicationController
     end
 
     @content = render_as_markdown(@asset_data)
+  end
+
+  def asset_params
+    params.require(:asset).permit(:filter_on, :filter_arg)
   end
 end

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -25,15 +25,15 @@ class AssetsController < ApplicationController
   def single_asset
     redirect_unless_bolt_on('Assets')
     @name = params[:name]
-    #TODO change command when the syntax loses the `show`
-    # (flight inventory issue #117)
-    #TODO `-f headnode` when that is implemented/for production
-    cmd = "flight inventory show document #{@name};"
+    cmd = "flight inventory show #{@name} -f diagram-markdown;"
     Bundler.with_clean_env do
       @asset_data = Open3.capture3(cmd)[0]
     end
-
-    @content = render_as_markdown(@asset_data)
+    if @asset_data =~ /<img\s*src=/
+      @content = @asset_data.html_safe
+    else
+      @content = render_as_markdown(@asset_data)
+    end
   end
 
   def asset_params

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -4,7 +4,7 @@ class AssetsController < ApplicationController
   def index
     redirect_unless_bolt_on('Assets')
     cmd = "flight inventory list"
-    if params[:filter_on] and params[:filter_arg]
+    if params[:filter_on] and !params[:filter_arg].blank?
       cmd = cmd + " --#{params[:filter_on]} #{params[:filter_arg].downcase}"
     end
     @assets = get_assets(cmd)

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -5,7 +5,7 @@ class AssetsController < ApplicationController
     redirect_unless_bolt_on('Assets')
     cmd = "flight inventory list"
     if params[:filter_on] and params[:filter_arg]
-      cmd = cmd + " --#{params[:filter_on]} #{params[:filter_arg]}"
+      cmd = cmd + " --#{params[:filter_on]} #{params[:filter_arg].downcase}"
     end
     @assets = get_assets(cmd)
   end

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -32,7 +32,7 @@ class AssetsController < ApplicationController
     #This ';' is neccessary to force shell execution
     #See here: https://stackoverflow.com/a/26040994/6257573
     cmd = cmd + ';' unless cmd.match(/;$/)
-    Bundler.with_clean_env { @asset_data = Open3.capture3(cmd)[0] }
+    Bundler.with_clean_env { Open3.capture3(cmd)[0] }
   end
 
   #TODO potentially implement caching to prevent unnecssarily re-executing

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -1,0 +1,20 @@
+class AssetsController < ApplicationController
+  require 'open3'
+
+  def index
+    redirect_unless_bolt_on('Assets')
+    @assets = {}
+    assets_list = ''
+    Bundler.with_clean_env do
+      #This ';' is neccessary to force shell execution
+      #See here: https://stackoverflow.com/a/26040994/6257573
+      assets_list = Open3.capture3("flight inventory list;")[0]
+    end
+    assets_by_type = assets_list.split("\n#")
+    assets_by_type.each do |type_list|
+      next if type_list.empty?
+      type_list = type_list.split("\n")
+      @assets[type_list.shift] = type_list
+    end
+  end
+end

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -16,6 +16,18 @@ class AssetsController < ApplicationController
     cmd = "flight inventory show #{@name} -f diagram-markdown;"
     @asset_data = execute(cmd)
     if @asset_data =~ /<img\s*src=/
+
+      asset_list = []
+      get_assets.each do |key, value|
+        asset_list.concat(value)
+      end
+
+      @asset_data.scan(/[\w-]+/).each do |w|
+        if asset_list.include?(w)
+          @asset_data[w] = view_context.link_to(w, assets_path + '/' + w)
+        end
+      end
+
       @content = @asset_data.html_safe
     else
       @content = render_as_markdown(@asset_data)

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -8,12 +8,7 @@ class AssetsController < ApplicationController
       cmd = cmd + " --#{params[:filter_on]} #{params[:filter_arg]}"
     end
     @assets = {}
-    assets_list = ''
-    Bundler.with_clean_env do
-      #This ';' is neccessary to force shell execution
-      #See here: https://stackoverflow.com/a/26040994/6257573
-      assets_list = Open3.capture3(cmd + ";")[0]
-    end
+    assets_list = execute(cmd)
     assets_by_type = assets_list.split("\n#")
     assets_by_type.each do |type_list|
       next if type_list.empty?
@@ -26,9 +21,7 @@ class AssetsController < ApplicationController
     redirect_unless_bolt_on('Assets')
     @name = params[:name]
     cmd = "flight inventory show #{@name} -f diagram-markdown;"
-    Bundler.with_clean_env do
-      @asset_data = Open3.capture3(cmd)[0]
-    end
+    @asset_data = execute(cmd)
     if @asset_data =~ /<img\s*src=/
       @content = @asset_data.html_safe
     else
@@ -38,5 +31,14 @@ class AssetsController < ApplicationController
 
   def asset_params
     params.require(:asset).permit(:filter_on, :filter_arg)
+  end
+
+  private
+  # currently just returns stdout, this may need to be altered
+  def execute(cmd)
+    #This ';' is neccessary to force shell execution
+    #See here: https://stackoverflow.com/a/26040994/6257573
+    cmd = cmd + ';' unless cmd.match(/;$/)
+    Bundler.with_clean_env { @asset_data = Open3.capture3(cmd)[0] }
   end
 end

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -17,4 +17,18 @@ class AssetsController < ApplicationController
       @assets[type_list.shift] = type_list
     end
   end
+
+  def single_asset
+    redirect_unless_bolt_on('Assets')
+    @name = params[:name]
+    #TODO change command when the syntax loses the `show`
+    # (flight inventory issue #117)
+    #TODO `-f headnode` when that is implemented/for production
+    cmd = "flight inventory show document #{@name};"
+    Bundler.with_clean_env do
+      @asset_data = Open3.capture3(cmd)[0]
+    end
+
+    @content = render_as_markdown(@asset_data)
+  end
 end

--- a/app/controllers/cluster_controller.rb
+++ b/app/controllers/cluster_controller.rb
@@ -1,6 +1,4 @@
 class ClusterController < ApplicationController
-  require 'commonmarker'
-
   def index
     #BoltOns
     @vpn = {
@@ -39,7 +37,7 @@ class ClusterController < ApplicationController
     file_data = IO.binread(file) if File.exist? file
 
     if file_data
-      CommonMarker.render_html(file_data, :DEFAULT, [:table])
+      render_as_markdown(file_data)
     end
   end
 

--- a/app/views/assets/index.html.erb
+++ b/app/views/assets/index.html.erb
@@ -16,7 +16,7 @@
           <h2> <%= type.downcase %> </h2>
           <p>
             <% assets.each do |a| %>
-              <span style="white-space: nowrap">
+              <span class="asset-name">
                 <%= link_to a, assets_path + '/' + a %>
               </span>
             <% end %>
@@ -26,5 +26,5 @@
     <% else %>
       No asset information found.
     <% end %>
-  <div>
+  </div>
 </div>

--- a/app/views/assets/index.html.erb
+++ b/app/views/assets/index.html.erb
@@ -1,4 +1,4 @@
-<div class="text-center">
+<div class="center text-center" style="width: 90%;">
   <div class="parent-div">
     <h1 class="visible-print-inline-block"> Asset Information </h1>
     <div class="filter-bar">

--- a/app/views/assets/index.html.erb
+++ b/app/views/assets/index.html.erb
@@ -13,7 +13,7 @@
     <% if @assets and not @assets.empty? %>
       <% @assets.each do |type, assets| %>
         <div class='card'>
-          <h2> <%= type %> </h2>
+          <h2> <%= type.downcase %> </h2>
           <p>
             <% assets.each do |a| %>
               <span style="white-space: nowrap">

--- a/app/views/assets/index.html.erb
+++ b/app/views/assets/index.html.erb
@@ -5,10 +5,10 @@
       <%= form_tag(assets_path, {method: :get, enforce_utf8: false, class: 'btn bordered'}) do  %>
         <%= select_tag :filter_on,
           options_for_select([['Group', 'group'], ['Type', 'type']]),
-          class: 'btn btn-bordered'
+          class: 'btn btn-bordered text-white'
         %>
         <%= text_field_tag :filter_arg %>
-        <%= submit_tag 'Filter', name: nil, class: 'btn btn-bordered' %>
+        <%= submit_tag 'Filter', name: nil, class: 'btn btn-bordered text-white' %>
       <% end %>
     </div>
   </div>

--- a/app/views/assets/index.html.erb
+++ b/app/views/assets/index.html.erb
@@ -1,0 +1,23 @@
+<div>
+  <div style="text-align: center;">
+    <h1> Asset Information </h1>
+  </div>
+  <div style="text-align: center">
+    <% if @assets and not @assets.empty? %>
+      <% @assets.each do |type, assets| %>
+        <div class='card'>
+          <h2> <%= type %> </h2>
+          <p>
+            <% assets.each do |a| %>
+              <span style="white-space: nowrap">
+                <%= link_to a, assets_path + '/' + a %>
+              </span>
+            <% end %>
+          </p>
+        </div>
+      <% end %>
+    <% else %>
+      No asset information found.
+    <% end %>
+  <div>
+</div>

--- a/app/views/assets/index.html.erb
+++ b/app/views/assets/index.html.erb
@@ -16,7 +16,7 @@
     <% if @assets and not @assets.empty? %>
       <% @assets.each do |type, assets| %>
         <div class='card'>
-          <h2> <%= type.downcase %> </h2>
+          <h2> <%= type.downcase.capitalize %> </h2>
           <p>
             <% assets.each do |a| %>
               <span class="asset-name">

--- a/app/views/assets/index.html.erb
+++ b/app/views/assets/index.html.erb
@@ -1,15 +1,18 @@
-<div>
-  <div style="text-align: center;">
-    <h1> Asset Information </h1>
+<div class="text-center">
+  <div class="parent-div">
+    <h1 class="visible-print-inline-block"> Asset Information </h1>
+    <div class="filter-bar">
+      <%= form_tag(assets_path, {method: :get, enforce_utf8: false, class: 'btn bordered'}) do  %>
+        <%= select_tag :filter_on,
+          options_for_select([['Group', 'group'], ['Type', 'type']]),
+          class: 'btn btn-bordered'
+        %>
+        <%= text_field_tag :filter_arg %>
+        <%= submit_tag 'Filter', name: nil, class: 'btn btn-bordered' %>
+      <% end %>
+    </div>
   </div>
   <div>
-    <%= form_tag assets_path, method: :get, enforce_utf8: false do  %>
-      <%= select_tag :filter_on, options_for_select([['Group', 'group'],['Type', 'type']]) %>
-      <%= text_field_tag :filter_arg %>
-      <%= submit_tag 'Filter', name: nil %>
-    <% end %>
-  </div>
-  <div style="text-align: center">
     <% if @assets and not @assets.empty? %>
       <% @assets.each do |type, assets| %>
         <div class='card'>

--- a/app/views/assets/index.html.erb
+++ b/app/views/assets/index.html.erb
@@ -2,6 +2,13 @@
   <div style="text-align: center;">
     <h1> Asset Information </h1>
   </div>
+  <div>
+    <%= form_tag assets_path, method: :get, enforce_utf8: false do  %>
+      <%= select_tag :filter_on, options_for_select([['Group', 'group'],['Type', 'type']]) %>
+      <%= text_field_tag :filter_arg %>
+      <%= submit_tag 'Filter', name: nil %>
+    <% end %>
+  </div>
   <div style="text-align: center">
     <% if @assets and not @assets.empty? %>
       <% @assets.each do |type, assets| %>

--- a/app/views/assets/index.html.erb
+++ b/app/views/assets/index.html.erb
@@ -1,13 +1,13 @@
 <div class="center text-center" style="width: 90%;">
   <div class="parent-div">
     <h1 class="visible-print-inline-block"> Asset Information </h1>
-    <div class="filter-bar">
+    <div class="filter-bar w-25">
       <%= form_tag(assets_path, {method: :get, enforce_utf8: false, class: 'btn bordered'}) do  %>
         <%= select_tag :filter_on,
           options_for_select([['Group', 'group'], ['Type', 'type']]),
           class: 'btn btn-bordered text-white'
         %>
-        <%= text_field_tag :filter_arg %>
+        <%= text_field_tag :filter_arg, "", class: 'form-control-sm', style: 'width: 30%;' %>
         <%= submit_tag 'Filter', name: nil, class: 'btn btn-bordered text-white' %>
       <% end %>
     </div>

--- a/app/views/assets/single_asset.html.erb
+++ b/app/views/assets/single_asset.html.erb
@@ -1,4 +1,4 @@
-<div class="card" style="width: 90%; margin: auto; margin-top: 2%">
+<div class="card" style="width: 90%; margin: auto; margin-top: 2%; margin-bottom: 2%">
   <h2 class="card-header" style="text-align: center"><%= @name %></h2>
   <div class="card-body">
     <% if @content and not @content.empty? %>

--- a/app/views/assets/single_asset.html.erb
+++ b/app/views/assets/single_asset.html.erb
@@ -1,0 +1,10 @@
+<div class="card" style="width: 90%; margin: auto; margin-top: 2%">
+  <h2 class="card-header" style="text-align: center"><%= @name %></h2>
+  <div class="card-body">
+    <% if @content.empty? %>
+      <div style="text-align: center">Unable to display information found for this asset.</div>
+    <% else %>
+      <%= simple_format @content %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/assets/single_asset.html.erb
+++ b/app/views/assets/single_asset.html.erb
@@ -2,7 +2,7 @@
   <h2 class="card-header" style="text-align: center"><%= @name %></h2>
   <div class="card-body">
     <% if @content and not @content.empty? %>
-      <%= simple_format @content %>
+      <%= @content.html_safe %>
     <% else %>
       <div style="text-align: center">Unable to display information for this asset.</div>
     <% end %>

--- a/app/views/assets/single_asset.html.erb
+++ b/app/views/assets/single_asset.html.erb
@@ -4,8 +4,7 @@
     <% if @content and not @content.empty? %>
       <%= simple_format @content %>
     <% else %>
-      <%#= TODO improve this message by reading the command's stdout%>
-      <div style="text-align: center">Unable to display information found for this asset.</div>
+      <div style="text-align: center">Unable to display information for this asset.</div>
     <% end %>
   </div>
 </div>

--- a/app/views/assets/single_asset.html.erb
+++ b/app/views/assets/single_asset.html.erb
@@ -1,10 +1,11 @@
 <div class="card" style="width: 90%; margin: auto; margin-top: 2%">
   <h2 class="card-header" style="text-align: center"><%= @name %></h2>
   <div class="card-body">
-    <% if @content.empty? %>
-      <div style="text-align: center">Unable to display information found for this asset.</div>
-    <% else %>
+    <% if @content and not @content.empty? %>
       <%= simple_format @content %>
+    <% else %>
+      <%#= TODO improve this message by reading the command's stdout%>
+      <div style="text-align: center">Unable to display information found for this asset.</div>
     <% end %>
   </div>
 </div>

--- a/app/views/partials/_navbar.html.erb
+++ b/app/views/partials/_navbar.html.erb
@@ -28,6 +28,12 @@
             method: :get
         %>
       <% end %>
+      <% if bolt_on_enabled('Assets') %>
+        <a class="nav-item nav-link <%= 'active' if current_page?(assets_path) %>"
+           href="<%= assets_path %>">
+           Asset Information
+        </a>
+      <% end %>
       <%= link_to "(#{current_user.username}) Sign Out",
           logout_path,
           method: :delete,

--- a/app/views/partials/_navbar.html.erb
+++ b/app/views/partials/_navbar.html.erb
@@ -31,7 +31,7 @@
       <% if bolt_on_enabled('Assets') %>
         <a class="nav-item nav-link <%= 'active' if current_page?(assets_path) %>"
            href="<%= assets_path %>">
-           Asset Information
+           Assets
         </a>
       <% end %>
       <%= link_to "(#{current_user.username}) Sign Out",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,8 @@ Rails.application.routes.draw do
 
     get 'console', to: 'console#index'
 
+    get 'assets', to: 'assets#index'
+
     delete  '/logout',  to: 'sessions#destroy'
 
     root 'cluster#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
     get 'console', to: 'console#index'
 
     get 'assets', to: 'assets#index'
+    get 'assets/:name', to: 'assets#single_asset'
 
     delete  '/logout',  to: 'sessions#destroy'
 

--- a/db/data/20190329161147_add_assets_bolt_on.rb
+++ b/db/data/20190329161147_add_assets_bolt_on.rb
@@ -1,0 +1,9 @@
+class AddAssetsBoltOn < ActiveRecord::Migration[5.2]
+  def up
+    BoltOn.create!(name: 'Assets')
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
Closes #25 

Adds a new bolt on for asset information.
This bolt on adds an new page, `/assets`, which contains a list of every asset maintained by flight inventory on the system, sorted by type. Each of these asset names is a link to a rendering of that assets template for the `diagram-markdown` format.
The list can be filtered by asset group or asset type. 

Requires `flight inventory` be installed on the server with `diagram-markdown` being a valid format in an`etc/templates.yml` file. It is recommended that the `flight inventory diagrams` plugin is installed. 

Designed to work with commit https://github.com/openflighthpc/flight-inventory/pull/129/commits/3d7c00babc4c52aef546249bb75786c54358db80 and https://github.com/alces-software/flight-inventory-diagrams/pull/1/commits/421981dfbab1c66439c4acd6a32ab9b51053f0aa, not at present time merged into main branches.

Screens:
![image](https://user-images.githubusercontent.com/24327288/56352200-a0c20700-61c6-11e9-943a-6846e7b4a686.png)
![image](https://user-images.githubusercontent.com/24327288/56352297-d36bff80-61c6-11e9-9791-dfee9c5c578f.png)
For a switch:
![image](https://user-images.githubusercontent.com/24327288/56353262-e7186580-61c8-11e9-9c76-d4321a67a7e1.png)
