### PR TITLE
Fix Markdown

### DIFF
--- a/app/assets/stylesheets/markdown.scss
+++ b/app/assets/stylesheets/markdown.scss
@@ -44,9 +44,9 @@
     width: unset;
   }
 
-  thead {
-    @extend .thead-dark;
-  }
+  // thead {
+  //   @extend .thead-dark;
+  // }
 
   pre {
     display: block;

--- a/app/assets/stylesheets/markdown.scss
+++ b/app/assets/stylesheets/markdown.scss
@@ -1,0 +1,109 @@
+@import "bootstrap/functions";
+@import "bootstrap/variables";
+@import "bootstrap/mixins";
+@import "bootstrap/tables";
+
+
+.markdown {
+  h1 {
+    font-size: 1.75rem;
+    .emoji-icon {
+      width: 1.75rem;
+      height: 1.75rem;
+    }
+  }
+
+  h2 {
+    font-size: 1.25rem;
+    .emoji-icon {
+      width: 1.25rem;
+      height: 1.25rem;
+    }
+  }
+
+  h3 {
+    font-size: 1rem;
+    .emoji-icon {
+      width: 1rem;
+      height: 1rem;
+    }
+  }
+
+  h4 {
+    font-size: 0.75rem;
+    .emoji-icon {
+      width: 0.75rem;
+      height: 0.75rem;
+    }
+  }
+
+  table {
+    @extend .table;
+    @extend .table-bordered;
+    @extend .table-sm;
+    width: unset;
+  }
+
+  thead {
+    @extend .thead-dark;
+  }
+
+  pre {
+    display: block;
+    color: #212529;
+    background: #f0f0f0;
+    padding: 5px;
+    border-radius: 5px;
+  }
+
+  code {
+    color: #212529;
+    word-break: break-word;
+    background-color: #f0f0f0;
+    padding: 3px;
+    border-radius: 5px;
+  }
+
+  pre code {
+    word-break: break-all;
+    white-space: pre-wrap;
+    padding: 0;
+  }
+
+  img {
+    max-width: 100%;
+  }
+
+  blockquote {
+    padding: 0 1em;
+    border-left: 0.25em solid #f0f0f0;
+  }
+
+  table.rouge-table {
+      border-radius: 5px;
+      background: #f0f0f0;
+      border: none;
+      width: 100%;
+
+      pre {
+          background: none;
+          margin-bottom: 0;
+      }
+
+      td:first-child {
+          width: 40px;
+          text-align: right;
+          border-right: 1px solid #dee2e6;
+          pre {
+              font-style: italic;
+              color: #999;
+              font-size: 10px;
+              line-height: 21px;
+          }
+      }
+
+      td, tr, tbody {
+          border: none;
+      }
+  }
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
   require 'open3'
 
   helper_method :bolt_on_enabled
+  helper_method :format_markdown
 
   def authenticate(params)
     User.authenticate(

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,7 +34,7 @@ class ApplicationController < ActionController::Base
     redirect_to root_path unless bolt_on_enabled(bolt_on)
   end
 
-  def render_as_markdown(html)
-    MarkdownRenderer.render(html)
+  def format_markdown(text)
+    MarkdownRenderer.render(text)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,6 +35,6 @@ class ApplicationController < ActionController::Base
   end
 
   def render_as_markdown(html)
-    CommonMarker.render_html(html, :DEFAULT, [:table])
+    MarkdownRenderer.render(html)
   end
 end

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -24,8 +24,8 @@ class AssetsController < ApplicationController
         asset_list.concat(value)
       end
 
-      parts[0] = render_as_markdown(parts[0])
-      parts[2] = render_as_markdown(parts[2])
+      parts[0] = format_markdown(parts[0])
+      parts[2] = format_markdown(parts[2])
 
       [parts[0], parts[2]].each do |p|
         p.scan(/[\w-]+/).each do |w|
@@ -37,7 +37,7 @@ class AssetsController < ApplicationController
 
       @content = parts.reduce{ |a, b| a + b }
     else
-      @content = render_as_markdown(@asset_data)
+      @content = format_markdown(@asset_data)
     end
   end
 

--- a/app/controllers/cluster_controller.rb
+++ b/app/controllers/cluster_controller.rb
@@ -36,9 +36,7 @@ class ClusterController < ApplicationController
     file = Rails.application.config.appliance_information
     file_data = IO.binread(file) if File.exist? file
 
-    if file_data
-      render_as_markdown(file_data)
-    end
+    render_as_markdown(file_data)
   end
 
   def vpn_status

--- a/app/controllers/cluster_controller.rb
+++ b/app/controllers/cluster_controller.rb
@@ -36,7 +36,7 @@ class ClusterController < ApplicationController
     file = Rails.application.config.appliance_information
     file_data = IO.binread(file) if File.exist? file
 
-    render_as_markdown(file_data)
+    format_markdown(file_data)
   end
 
   def vpn_status

--- a/app/models/concerns/markdown.rb
+++ b/app/models/concerns/markdown.rb
@@ -1,0 +1,26 @@
+module MarkdownRenderer
+  def self.render(markdown_text)
+    html_doc = CommonMarker.render_doc(
+      markdown_text || '',
+      :SMART,
+      [
+        :table,
+        :tagfilter,
+        :autolink,
+        :strikethrough
+      ]
+    ).to_html(
+      [
+        :GITHUB_PRE_LANG,
+        :HARDBREAKS,
+      ],
+      [:tagfilter]
+    ).strip
+
+    if html_doc.empty?
+      ''
+    else
+      "<div class=\"markdown\">\n#{html_doc}\n</div>"
+    end
+  end
+end

--- a/app/views/cluster/index.html.erb
+++ b/app/views/cluster/index.html.erb
@@ -4,7 +4,7 @@
   <div class="card" style="width: 70%;">
     <h5 class="card-header">Information</h5>
     <div class="card-body">
-      <% if @content %>
+      <% unless @content.empty? %>
         <%= @content.html_safe %>
       <% else %>
         There is no appliance information to display.

--- a/app/views/network/index.html.erb
+++ b/app/views/network/index.html.erb
@@ -22,7 +22,7 @@
           </div>
           <div class="card-body">
             <% network.each do |variable| %>
-              <%= CommonMarker.render_html(variable, :DEFAULT, [:table]).html_safe %>
+              <%= format_markdown(variable).html_safe %>
             <% end %>
           </div>
         </div>


### PR DESCRIPTION
The way in which Markdown is rendered has been changed to revolve around the new `MarkdownRenderer` module. This module contains a single `render` method that handles how the content is rendered using `CommonMarker` and ensures the output is wrapped in a `div` with the correct styling. Therefore elements such as tables that previously didn't work as we wanted should now be rendered correctly.