### PR TITLE
Add title to asset pages

### DIFF
--- a/app/views/assets/single_asset.html.erb
+++ b/app/views/assets/single_asset.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title) { @name } %>
+
 <div class="card" style="width: 90%; margin: auto; margin-top: 2%; margin-bottom: 2%">
   <h2 class="card-header" style="text-align: center"><%= @name %></h2>
   <div class="card-body">


### PR DESCRIPTION
Each individual asset page will now display the name of the asset as the page title.