### PR TITLE
Refactor asset listing

### DIFF
--- a/app/assets/javascripts/assets.js
+++ b/app/assets/javascripts/assets.js
@@ -1,5 +1,5 @@
 function changeIconOnClick() {
-  $('#accordion h5 a').click(function(e){
+  $('h5 a').click(function(e){
     var card = $(e.target).closest('div.card');
     var img = $('i', card)[0];
 

--- a/app/assets/javascripts/assets.js
+++ b/app/assets/javascripts/assets.js
@@ -1,0 +1,16 @@
+function changeIconOnClick() {
+  $('#accordion h5 a').click(function(e){
+    var card = $(e.target).closest('div.card');
+    var img = $('i', card)[0];
+
+    if (img.classList.contains('fa-plus')) {
+      img.classList.remove('fa-plus');
+      img.classList.add('fa-minus');
+    } else {
+      img.classList.remove('fa-minus');
+      img.classList.add('fa-plus');
+    }
+  });
+}
+
+document.addEventListener('turbolinks:load', changeIconOnClick);

--- a/app/views/assets/index.html.erb
+++ b/app/views/assets/index.html.erb
@@ -24,18 +24,29 @@
       <% end %>
     </div>
   </div>
-  <div>
+  <br>
+  <div id="accordion" class="center w-25">
     <% if @assets and not @assets.empty? %>
       <% @assets.each do |type, assets| %>
-        <div class='card'>
-          <h2> <%= type.downcase.capitalize %> </h2>
-          <p>
-            <% assets.each do |a| %>
-              <span class="asset-name">
-                <%= link_to a, assets_path + '/' + a %>
-              </span>
-            <% end %>
-          </p>
+        <div class="card mb-1">
+          <div class="card-header">
+            <h5 class="mb-0">
+              <a data-toggle="collapse" href="#<%= type %>">
+                <%= type.downcase.capitalize %>
+              </a>
+              <i class="fa fa-minus fa-pull-right mt-1"></i>
+            </h5>
+          </div>
+
+          <div id="<%= type %>" class="collapse show" data-parent="#accordion">
+            <div class="card-body">
+              <div class="list-group">
+                <% assets.each do |a| %>
+                  <%= link_to a, assets_path + '/' + a, class: 'list-group-item list-group-item-action' %>
+                <% end %>
+              </div>
+            </div>
+          </div>
         </div>
       <% end %>
     <% else %>

--- a/app/views/assets/index.html.erb
+++ b/app/views/assets/index.html.erb
@@ -25,25 +25,26 @@
     </div>
   </div>
   <br>
-  <div id="accordion" class="center w-25">
     <% if @assets and not @assets.empty? %>
       <% @assets.each do |type, assets| %>
-        <div class="card mb-1">
-          <div class="card-header">
-            <h5 class="mb-0">
-              <a data-toggle="collapse" href="#<%= type %>">
-                <%= type.downcase.capitalize %>
-              </a>
-              <i class="fa fa-minus fa-pull-right mt-1"></i>
-            </h5>
-          </div>
+        <div id="accordion-<%= type.downcase %>" class="center w-25">
+          <div class="card mb-1">
+            <div class="card-header">
+              <h5 class="mb-0">
+                <a data-toggle="collapse" href="#<%= type %>">
+                  <%= type.downcase.capitalize %>
+                </a>
+                <i class="fa fa-minus fa-pull-right mt-1"></i>
+              </h5>
+            </div>
 
-          <div id="<%= type %>" class="collapse show" data-parent="#accordion">
-            <div class="card-body">
-              <div class="list-group">
-                <% assets.each do |a| %>
-                  <%= link_to a, assets_path + '/' + a, class: 'list-group-item list-group-item-action' %>
-                <% end %>
+            <div id="<%= type %>" class="collapse show" data-parent="#accordion-<%= type.downcase %>">
+              <div class="card-body">
+                <div class="list-group">
+                  <% assets.each do |a| %>
+                    <%= link_to a, assets_path + '/' + a, class: 'list-group-item list-group-item-action' %>
+                  <% end %>
+                </div>
               </div>
             </div>
           </div>
@@ -52,5 +53,4 @@
     <% else %>
       No asset information found.
     <% end %>
-  </div>
 </div>


### PR DESCRIPTION
Assets are no longer listed as a big block of text. Each asset type now has a collapsible card that displays their respective assets as a list-group. The overall functionality for this page remains the same.

![asset-listing](https://user-images.githubusercontent.com/36155339/56806760-c3869800-6824-11e9-8008-ddb6140c5606.gif)
