### PR TITLE
Switch template to be used with Flight Inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,4 @@ Prerequisites:
 
 * [Flight Inventory](https://github.com/openflighthpc/flight-inventory) installed
 * [Flight Inventory Diagrams](https://github.com/alces-software/flight-inventory-diagrams) plugin installed
+* [Template](https://github.com/alces-software/overware/templates/switchOW.md.erb) moved to the `templates` directory of the `Flight Inventory` install

--- a/README.md
+++ b/README.md
@@ -102,4 +102,4 @@ Prerequisites:
 
 * [Flight Inventory](https://github.com/openflighthpc/flight-inventory) installed
 * [Flight Inventory Diagrams](https://github.com/alces-software/flight-inventory-diagrams) plugin installed
-* [Template](https://github.com/alces-software/overware/templates/switchOW.md.erb) moved to the `templates` directory of the `Flight Inventory` install
+* [Template](templates/switchOW.md.erb) moved to the `templates` directory of the `Flight Inventory` install

--- a/README.md
+++ b/README.md
@@ -103,3 +103,11 @@ Prerequisites:
 * [Flight Inventory](https://github.com/openflighthpc/flight-inventory) installed
 * [Flight Inventory Diagrams](https://github.com/alces-software/flight-inventory-diagrams) plugin installed
 * [Template](templates/switchOW.md.erb) moved to the `templates` directory of the `Flight Inventory` install
+* Within `Flight Inventory` add the following to the `etc/templates.yml` file:
+
+    ```
+    overware:
+      default: server.md.erb
+      server: server.md.erb
+      switch: switchOW.md.erb
+    ```

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -13,7 +13,7 @@ class AssetsController < ApplicationController
   def single_asset
     redirect_unless_bolt_on('Assets')
     @name = params[:name]
-    cmd = "flight inventory show #{@name} -f diagram-markdown;"
+    cmd = "flight inventory show #{@name} -t switchOW;"
     @asset_data = execute(cmd)
     @content = format_markdown(@asset_data)
   end

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -13,7 +13,7 @@ class AssetsController < ApplicationController
   def single_asset
     redirect_unless_bolt_on('Assets')
     @name = params[:name]
-    cmd = "flight inventory show #{@name} -t switchOW;"
+    cmd = "flight inventory show #{@name} -f overware;"
     @asset_data = execute(cmd)
     @content = format_markdown(@asset_data)
   end

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -15,30 +15,7 @@ class AssetsController < ApplicationController
     @name = params[:name]
     cmd = "flight inventory show #{@name} -f diagram-markdown;"
     @asset_data = execute(cmd)
-    img_regex = /<img\ssrc=.+>/
-    if @asset_data.match?(img_regex)
-      parts = @asset_data.partition(img_regex)
-
-      asset_list = []
-      get_assets.each do |key, value|
-        asset_list.concat(value)
-      end
-
-      parts[0] = format_markdown(parts[0])
-      parts[2] = format_markdown(parts[2])
-
-      [parts[0], parts[2]].each do |p|
-        p.scan(/[\w-]+/).each do |w|
-          if asset_list.include?(w)
-            p[w] = view_context.link_to(w, assets_path + '/' + w)
-          end
-        end
-      end
-
-      @content = parts.reduce{ |a, b| a + b }
-    else
-      @content = format_markdown(@asset_data)
-    end
+    @content = format_markdown(@asset_data)
   end
 
   def asset_params

--- a/app/models/concerns/markdown.rb
+++ b/app/models/concerns/markdown.rb
@@ -13,6 +13,7 @@ module MarkdownRenderer
       [
         :GITHUB_PRE_LANG,
         :HARDBREAKS,
+        :UNSAFE,
       ],
       [:tagfilter]
     ).strip

--- a/templates/switchOW.md.erb
+++ b/templates/switchOW.md.erb
@@ -1,0 +1,20 @@
+# <a href="<%= @asset_data.name %>"><%= @asset_data.name %></a>
+
+<% @asset_hash['mutable']['maps'].each do |map| %>
+
+## <%= map.first %>
+
+<img class="mb-2" src="data:image/svg+xml;base64,<%= render_switch_base64(
+map[1]['map'],
+width: map[1]['map_width'],
+height: map[1]['map_height'],
+layout: map[1]['map_layout'],
+)%>">
+
+
+|Port|Note|
+|----|----|
+<% (map[1]['map'] || {}).to_h.each do |k,v| -%>
+|<%= k %>|<a href="<%= v %>"><%= v %></a>|
+<% end %>
+<% end %>


### PR DESCRIPTION
This PR adds an Overware specific template for use with `Flight Inventory` and `Flight Inventory Diagrams`. With this being housed within this repo it does mean a few extra steps need to be made for installs of Overware to be fully functional with all available bolt-ons. 

Extra actions that need to be taken:
* Move the template to the `templates` directory of the `Flight Inventory` install
* Adjust the `etc/templates.yml` file within `Flight Inventory` as described in this repo's `README` 

For full details look at the relevant section within the `README`.