### PR TITLE
Allow blank input on the asset filter bar

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -4,7 +4,7 @@ class AssetsController < ApplicationController
   def index
     redirect_unless_bolt_on('Assets')
     cmd = "flight inventory list"
-    if params[:filter_on] and !params[:filter_arg].blank?
+    if params[:filter_on]
       cmd = cmd + " --#{params[:filter_on]} #{params[:filter_arg].downcase}"
     end
     @assets = get_assets(cmd)

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -3,15 +3,19 @@ class AssetsController < ApplicationController
 
   def index
     redirect_unless_bolt_on('Assets')
+
     cmd = "flight inventory list"
+
     if params[:filter_on]
       cmd = cmd + " --#{params[:filter_on]} #{params[:filter_arg].downcase}"
     end
+
     @assets = get_assets(cmd)
   end
 
   def single_asset
     redirect_unless_bolt_on('Assets')
+
     @name = params[:name]
     cmd = "flight inventory show #{@name} -f overware;"
     @asset_data = execute(cmd)
@@ -23,6 +27,7 @@ class AssetsController < ApplicationController
   end
 
   private
+
   # currently just returns stdout, this may need to be altered
   def execute(cmd)
     #This ';' is neccessary to force shell execution


### PR DESCRIPTION
This change is to mirror [changes](https://github.com/openflighthpc/flight-inventory/pull/139) done to `Flight Inventory`.