### PR TITLE
Display the active cluster on the asset page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -51,3 +51,10 @@ textarea {
   max-width: initial;
   max-width: max-content;
 }
+
+a.fill-container {
+  display: block;
+  height: 100%;
+  width: 100%;
+  text-decoration: none;
+}

--- a/app/assets/stylesheets/assets.scss
+++ b/app/assets/stylesheets/assets.scss
@@ -14,3 +14,13 @@
   white-space: nowrap;
   padding: 0px 4px;
 }
+
+h1 span {
+  position: relative;
+}
+
+h1 span i {
+  position: absolute;
+  right: calc(100% + 20px);
+  margin-top: 0.5rem !important;
+}

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -5,6 +5,8 @@ class AssetsController < ApplicationController
     redirect_unless_bolt_on('Assets')
 
     cmd = "flight inventory list"
+    @active_cluster = execute("flight inventory list-cluster").
+      lines.first.remove('*').strip.capitalize
 
     if params[:filter_on]
       cmd = cmd + " --#{params[:filter_on]} #{params[:filter_arg].downcase}"

--- a/app/views/assets/index.html.erb
+++ b/app/views/assets/index.html.erb
@@ -24,6 +24,12 @@
       <% end %>
     </div>
   </div>
+  <div>
+    <h1>
+      <i class="fa fa-server"></i>
+      <%= @active_cluster %>
+    </h1>
+  </div>
   <br>
     <% if @assets and not @assets.empty? %>
       <% @assets.each do |type, assets| %>

--- a/app/views/assets/index.html.erb
+++ b/app/views/assets/index.html.erb
@@ -24,12 +24,12 @@
       <% end %>
     </div>
   </div>
-  <div>
-    <h1>
+  <h1>
+    <span>
       <i class="fa fa-server"></i>
       <%= @active_cluster %>
-    </h1>
-  </div>
+    </span>
+  </h1>
   <br>
     <% if @assets and not @assets.empty? %>
       <% @assets.each do |type, assets| %>

--- a/app/views/assets/index.html.erb
+++ b/app/views/assets/index.html.erb
@@ -37,10 +37,10 @@
           <div class="card mb-1">
             <div class="card-header">
               <h5 class="mb-0">
-                <a data-toggle="collapse" href="#<%= type %>">
+                <a data-toggle="collapse" href="#<%= type %>" class="fill-container">
                   <%= type.downcase.capitalize %>
+                  <i class="fa fa-minus fa-pull-right mt-1"></i>
                 </a>
-                <i class="fa fa-minus fa-pull-right mt-1"></i>
               </h5>
             </div>
 


### PR DESCRIPTION
Now that `Flight Inventory` supports clusters it felt necessary to display the currently active cluster that `Overware` is pulling the asset list from.

You might also notice that more space of the card headers is now clickable.

![image](https://user-images.githubusercontent.com/36155339/57940298-143d5e00-78c4-11e9-9ac5-f5902ea14a89.png)
