### PR TITLE
Remove redundant ternary statement

### DIFF
--- a/app/views/cluster/_vpn_controls.html.erb
+++ b/app/views/cluster/_vpn_controls.html.erb
@@ -10,7 +10,7 @@
         <% ['start', 'restart'].each do |action| %>
           <%= link_to action.capitalize,
                       public_send("vpn_#{action}_path"),
-                      class: "btn #{action == 'stop' ? 'btn-danger' : 'btn-primary' }",
+                      class: 'btn btn-primary',
                       style: 'width: 33%;',
                       method: :post
           %>


### PR DESCRIPTION
The `stop` action is handled separately and therefore this conditional is no longer relevant.

[Trello](https://trello.com/c/STErSHR8/38-remove-redundancy-from-vpn-controls)