### PR TITLE
Switch the active cluster

### DIFF
--- a/app/assets/stylesheets/assets.scss
+++ b/app/assets/stylesheets/assets.scss
@@ -14,3 +14,9 @@
   white-space: nowrap;
   padding: 0px 4px;
 }
+
+.dropdown-toggle::after {
+  float: right;
+  margin-top: 0.7rem !important;
+  margin-right: 0.4rem !important;
+}

--- a/app/assets/stylesheets/assets.scss
+++ b/app/assets/stylesheets/assets.scss
@@ -20,3 +20,7 @@
   margin-top: 0.7rem !important;
   margin-right: 0.4rem !important;
 }
+
+.dropdown-menu {
+  min-width: 100% !important;
+}

--- a/app/assets/stylesheets/assets.scss
+++ b/app/assets/stylesheets/assets.scss
@@ -14,13 +14,3 @@
   white-space: nowrap;
   padding: 0px 4px;
 }
-
-h1 span {
-  position: relative;
-}
-
-h1 span i {
-  position: absolute;
-  right: calc(100% + 20px);
-  margin-top: 0.5rem !important;
-}

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -4,9 +4,11 @@ class AssetsController < ApplicationController
   def index
     redirect_unless_bolt_on('Assets')
 
+    change_active_cluster if params[:cluster]
+
     cmd = "flight inventory list"
-    @active_cluster = execute("flight inventory list-cluster").
-      lines.first.remove('*').strip.capitalize
+    @clusters = execute("flight inventory list-cluster").lines.map { |c| c.strip }
+    @active_cluster = @clusters.shift.remove('* ').capitalize
 
     if params[:filter_on]
       cmd = cmd + " --#{params[:filter_on]} #{params[:filter_arg].downcase}"
@@ -49,5 +51,9 @@ class AssetsController < ApplicationController
      assets_by_type[type_list.shift] = type_list
    end
    assets_by_type
+  end
+
+  def change_active_cluster
+    execute("flight inventory switch-cluster #{params[:cluster]}")
   end
 end

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -8,7 +8,11 @@ class AssetsController < ApplicationController
 
     cmd = "flight inventory list"
     @clusters = execute("flight inventory list-cluster").lines.map { |c| c.strip }
-    @active_cluster = @clusters.shift.remove('* ').capitalize
+    @active_cluster = unless @clusters.empty?
+                        @clusters.shift.remove('* ').capitalize
+                      else
+                        'Default'
+                      end
 
     if params[:filter_on]
       cmd = cmd + " --#{params[:filter_on]} #{params[:filter_arg].downcase}"

--- a/app/views/assets/index.html.erb
+++ b/app/views/assets/index.html.erb
@@ -35,10 +35,14 @@
         </span>
       </button>
       <div class="dropdown-menu border-secondary text-center">
-        <% @clusters.select { |c| c != @active_cluster }.each do |cluster| %>
-          <a class="dropdown-item" href="<%= assets_path(cluster: cluster) %>">
-            <%= cluster %>
-          </a>
+        <% unless @clusters.empty? %>
+          <% @clusters.select { |c| c != @active_cluster }.each do |cluster| %>
+            <a class="dropdown-item" href="<%= assets_path(cluster: cluster) %>">
+              <%= cluster %>
+            </a>
+          <% end %>
+        <% else %>
+          <h6 class="dropdown-header">No clusters available to switch to</h6>
         <% end %>
       </div>
     </div>

--- a/app/views/assets/index.html.erb
+++ b/app/views/assets/index.html.erb
@@ -34,7 +34,7 @@
           <%= @active_cluster %>
         </span>
       </button>
-      <div class="dropdown-menu border-secondary">
+      <div class="dropdown-menu border-secondary text-center">
         <% @clusters.select { |c| c != @active_cluster }.each do |cluster| %>
           <a class="dropdown-item" href="<%= assets_path(cluster: cluster) %>">
             <%= cluster %>

--- a/app/views/assets/index.html.erb
+++ b/app/views/assets/index.html.erb
@@ -34,7 +34,7 @@
           <%= @active_cluster %>
         </span>
       </button>
-      <div class="dropdown-menu">
+      <div class="dropdown-menu border-secondary">
         <% @clusters.select { |c| c != @active_cluster }.each do |cluster| %>
           <a class="dropdown-item" href="<%= assets_path(cluster: cluster) %>">
             <%= cluster %>

--- a/app/views/assets/index.html.erb
+++ b/app/views/assets/index.html.erb
@@ -25,12 +25,12 @@
     </div>
   </div>
   <h1>
-    <div class="dropdown">
-      <button class="btn btn-outline-dark btn-lg dropdown-toggle m-2"
+    <div class="dropdown center w-25">
+      <button class="btn btn-outline-dark btn-lg dropdown-toggle my-2 w-100"
               type="button"
               data-toggle="dropdown">
         <span data-toggle="tooltip" title="Change the active cluster">
-          <i class="fa fa-server"></i>
+          <i class="fa fa-server fa-pull-left mt-1 ml-1"></i>
           <%= @active_cluster %>
         </span>
       </button>

--- a/app/views/assets/index.html.erb
+++ b/app/views/assets/index.html.erb
@@ -25,12 +25,24 @@
     </div>
   </div>
   <h1>
-    <span>
-      <i class="fa fa-server"></i>
-      <%= @active_cluster %>
-    </span>
+    <div class="dropdown">
+      <button class="btn btn-outline-dark btn-lg dropdown-toggle m-2"
+              type="button"
+              data-toggle="dropdown">
+        <span data-toggle="tooltip" title="Change the active cluster">
+          <i class="fa fa-server"></i>
+          <%= @active_cluster %>
+        </span>
+      </button>
+      <div class="dropdown-menu">
+        <% @clusters.select { |c| c != @active_cluster }.each do |cluster| %>
+          <a class="dropdown-item" href="<%= assets_path(cluster: cluster) %>">
+            <%= cluster %>
+          </a>
+        <% end %>
+      </div>
+    </div>
   </h1>
-  <br>
   <% if @assets and not @assets.empty? %>
     <% @assets.each do |type, assets| %>
       <div id="accordion-<%= type.downcase %>" class="center w-25">


### PR DESCRIPTION
This PR introduces the ability to switch the active cluster from the Assets page. Doing so changes the currently active cluster for use within Flight Inventory. 

[Trello](https://trello.com/c/8oOANgD3/36-dynamically-switch-clusters)